### PR TITLE
Update upload-artifact action to v4 in CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,7 +42,7 @@ jobs:
               --cov-report=term
         
     - name: Upload test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: test-results


### PR DESCRIPTION
Bumps the actions/upload-artifact GitHub Action from v3 to v4 in the pytest workflow to use the latest version.